### PR TITLE
Switch to ISO 8601 with Z-notation

### DIFF
--- a/lib/transformers/date_time.dart
+++ b/lib/transformers/date_time.dart
@@ -5,5 +5,5 @@ import 'package:dartson/type_transformer.dart';
 /// A simple DateTime transformer which uses the toString() method.
 class DateTimeParser extends TypeTransformer<DateTime> {
   DateTime decode(dynamic value) => DateTime.parse(value);
-  dynamic encode(DateTime value) => value.toString();
+  dynamic encode(DateTime value) => value.toUtc().toIso8601String();
 }


### PR DESCRIPTION
ISO8601 with Z-notation is what's the most commonly used format for representing Dates in JSON (at least it's what's used in all browser's Javascript default JSON serializers).