### PR TITLE
Upgrade logging

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   analyzer: ">=0.22.4 <0.25.1"
   barback: ">=0.15.2+2 <0.16.0"
-  logging: ">=0.9.3 <0.10.0"
+  logging: ">=0.9.3 <0.11.0"
   source_maps: ">=0.10.0 <0.11.0"
   source_span: ">=1.0.3 <1.1.0"
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   analyzer: ">=0.22.4 <0.25.1"
   barback: ">=0.15.2+2 <0.16.0"
-  logging: ">=0.9.3 <0.11.0"
+  logging: ">=0.9.3 <=0.11.0"
   source_maps: ">=0.10.0 <0.11.0"
   source_span: ">=1.0.3 <1.1.0"
 dev_dependencies:


### PR DESCRIPTION
Some popular libraries such as mongo_dart requires at least v0.11.0 to run

Tests pass