### PR TITLE
Check for Simple objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,6 @@ pubspec.lock
 .idea
 doc-viewer/
 test/tmp/
+.projects
+.packages
 .pub

--- a/lib/dartson.dart
+++ b/lib/dartson.dart
@@ -153,6 +153,14 @@ class Dartson<T> {
       fieldName = prop.name;
     }
 
+    //Check if simple value
+    if(value != null && _isSimpleType(value.runtimeType) && (prop != null ? !prop.ignore : true) )
+    {
+      result[fieldName] = value;
+      return;
+    }
+
+    //Check if complex value
     if (value != null && (prop != null ? !prop.ignore : true)) {
       _log.finer("Serializing field: ${fieldName}");
       result[fieldName] = serialize(value);

--- a/lib/dartson.dart
+++ b/lib/dartson.dart
@@ -100,7 +100,14 @@ class Dartson<T> {
   Map _serializeMap(Map object) {
     var map = {};
     object.forEach((k, v) {
-      if (v != null) map[k] = serialize(v);
+      if (v != null) {
+        if(_isSimpleType(v.runtimeType))
+        {
+          map[k] = v;
+        } else {
+          map[k] = serialize(v);
+        }
+      }
     });
     return map;
   }

--- a/lib/src/core_transformers.dart
+++ b/lib/src/core_transformers.dart
@@ -9,6 +9,7 @@ final Symbol _QN_BOOL = reflectClass(bool).qualifiedName;
 final Symbol _QN_LIST = reflectClass(List).qualifiedName;
 final Symbol _QN_MAP = reflectClass(Map).qualifiedName;
 final Symbol _QN_OBJECT = reflectClass(Object).qualifiedName;
+final Symbol _QN_DOUBLE = reflectClass(double).qualifiedName;
 
 var _qn = (Type t) => _getName(reflectClass(t).qualifiedName);
 
@@ -23,6 +24,7 @@ final Map<String, TypeTransformer> _simpleTransformers = {
   _qn(List): _defaultSimpleTransformer,
   _qn(Map): _defaultSimpleTransformer,
   _qn(Object): _defaultSimpleTransformer,
+  _qn(double): _defaultSimpleTransformer,
   'dart.core._OneByteString': _defaultSimpleTransformer,
   'dart.core._Smi': _defaultSimpleTransformer
 };

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -18,6 +18,7 @@ bool _isSimpleType(Type type) {
       type == bool ||
       type == String ||
       type == num ||
+      type == int ||
       type == double ||
       type == Map ||
       type == dynamic;

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -18,6 +18,7 @@ bool _isSimpleType(Type type) {
       type == bool ||
       type == String ||
       type == num ||
+      type == double ||
       type == Map ||
       type == dynamic;
 }

--- a/test/dartson_test.dart
+++ b/test/dartson_test.dart
@@ -82,12 +82,21 @@ void main() {
 
   test('parse: parser simple', () {
     TestClass1 test = dson.decode(
-        '{"name":"test","matter":true,"intNumber":2,"number":5,"list":[1,2,3],"map":{"k":"o"},"the_renamed":"test"}',
+        '{"name":"test",'
+            '"matter":true,'
+            '"intNumber":2,'
+            '"aDouble":50.555,'
+            '"number":50.1,'
+            '"list":[1,2,3],'
+            '"map":{"k":"o"},'
+            '"the_renamed":"test"}',
         new TestClass1());
+
     expect(test.name, 'test');
     expect(test.matter, true);
     expect(test.intNumber, 2);
-    expect(test.number, 5);
+    expect(test.number, 50.1);
+    expect(test.aDouble, 50.555);
     expect(test.list.length, 3);
     expect(test.list[1], 2);
     expect(test.map["k"], "o");
@@ -201,6 +210,32 @@ void main() {
     var str = dson.encode(obj);
     expect(str, '{"testDate":"${obj.testDate.toString()}"}');
   });
+
+  test('map: parse complex object)', () {
+    Map params = new Map();
+    params['name'] = "Test";
+    params['matter'] = true;
+    params['intNumber'] = 2;
+    params['aDouble'] = 3.14159;
+    params['number'] = 50.1;
+    params['numberTwo'] = 50.15;
+    params['list'] = [1,2,3];
+    params['map'] = {"k":"o"};
+    params['the_renamed'] = "test";
+
+    TestClass1 test = dson.map(params, new TestClass1() );
+
+    expect(test.name, 'Test');
+    expect(test.matter, true);
+    expect(test.intNumber, 2);
+    expect(test.number, 50.1);
+    expect(test.numberTwo, 50.15);
+    expect(test.aDouble, 3.14159);
+    expect(test.list.length, 3);
+    expect(test.list[1], 2);
+    expect(test.map["k"], "o");
+    expect(test.renamed, "test");
+  });
 }
 
 class SimpleTransformer extends TypeTransformer<DateTime> {
@@ -220,11 +255,13 @@ class SimpleDateContainer {
 class TestClass1 {
   String name;
   bool matter;
+  int intNumber;
   num number;
+  num numberTwo;
+  double aDouble;
   List list;
   Map map;
   TestClass1 child;
-  int intNumber;
 
   @Property(ignore: true)
   bool ignored;

--- a/test/dartson_test.dart
+++ b/test/dartson_test.dart
@@ -10,6 +10,12 @@ import 'dart:mirrors';
 void main() {
   var dson = new Dartson.JSON();
 
+  Map payload = {"collection_key":"Purchases","flightID":1006,"flightLevel":3,"ccn":60.0,"ccv":64.0,"bZip":50.0,"ccType":"mastercard"};
+  test("Serialize a payload with mixed numeric types", () {
+    dson.serialize(payload);
+    expect(true, true);
+  });
+
   test('serialize: simple array test', () {
     String str = dson.encode(['test1', 'test2']);
     expect(str, '["test1","test2"]');


### PR DESCRIPTION
Looks like double wasn't added to the list - this enables the 'parser simple' to pass using doubles.

Also check for simply types instead of doing recursive lookups on all objects. This will prevent going down the tree to infinity for boxed objects. 
