### PR TITLE
Update analyzer dependency for broader compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/eredo/dartson
 environment:
   sdk: '>=1.3.0'
 dependencies:
-  analyzer: ">=0.22.4 <0.27.0"
+  analyzer: ^0.22.4
   barback: ">=0.15.2+2 <0.16.0"
   logging: ">=0.9.3 <0.12.0"
   source_maps: ">=0.10.0 <0.11.0"


### PR DESCRIPTION
Dartson works fine with analyzer >0.27.0, but keeping it under that version breaks compatibility with other packages, including Polymer 1.0 RC 11+